### PR TITLE
Fix typo on .complement() naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.1] - TBD
+
+### Fixed
+* Typo in `.complement()` naming at [PR #43](https://github.com/TinyCommunity/tinycolor2/pull/43)
+
 ## [2.0.0] - 2021-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,14 +230,14 @@ TinyColor(Colors.red).spin(0).color;
 TinyColor(Colors.red).spin(360).color;
 ```
 
-### compliment
+### complement
 
-`compliment: function() -> TinyColor`. Returns the Complimentary Color for dynamic matching.
+`complement: function() -> TinyColor`. Returns the complementary color for dynamic matching.
 
 ```dart
-TinyColor(Colors.red).compliment().color;
+TinyColor(Colors.red).complement().color;
 // or with Color extension
-Colors.red.compliment;
+Colors.red.complement();
 ```
 
 ### mix

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -87,7 +87,7 @@ Color c = Colors.blue
             color: tc.spin(90).color,
           ),
           _createListItem(
-            title: "tc.compliment()",
+            title: "tc.complement()",
             subtitle: "c.complement()",
             color: tc.complement().color,
           ),

--- a/lib/src/color_extension.dart
+++ b/lib/src/color_extension.dart
@@ -52,8 +52,8 @@ extension TinyColorExtension on Color {
   /// Return a boolean indicating whether the color's perceived brightness is dark.
   bool get isDark => TinyColor(this).isDark();
 
-  /// Returns the Complimentary Color for dynamic matching
-  Color get compliment => TinyColor(this).complement().color;
+  /// Returns the complementary color for dynamic matching
+  Color get complement => TinyColor(this).complement().color;
 
   /// Blends the color with another color a given amount, from 0 - 100, default 50.
   Color mix(Color toColor, [int amount = 50]) => TinyColor(this)

--- a/lib/src/color_extension.dart
+++ b/lib/src/color_extension.dart
@@ -53,7 +53,7 @@ extension TinyColorExtension on Color {
   bool get isDark => TinyColor(this).isDark();
 
   /// Returns the complementary color for dynamic matching
-  Color get complement => TinyColor(this).complement().color;
+  Color complement() => TinyColor(this).complement().color;
 
   /// Blends the color with another color a given amount, from 0 - 100, default 50.
   Color mix(Color toColor, [int amount = 50]) => TinyColor(this)


### PR DESCRIPTION
See [original name](https://github.com/bgrins/TinyColor#complement).