### PR TITLE
Fix .greyscale() should be a method, not a property in Color extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.1] - TBD
+
+### Fixed
+* `.greyscale()` should be a method, not a property in `Color` extension at [PR #45](https://github.com/TinyCommunity/tinycolor2/pull/45)
+
 ## [2.0.0] - 2021-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Colors.red.saturate(50);
 ```dart
 TinyColor(Colors.red).greyscale().color;
 // or with Color extension
-Colors.red.greyscale;
+Colors.red.greyscale();
 ```
 
 ### spin

--- a/lib/src/color_extension.dart
+++ b/lib/src/color_extension.dart
@@ -35,7 +35,7 @@ extension TinyColorExtension on Color {
   Color saturate([int amount = 10]) => TinyColor(this).saturate(amount).color;
 
   /// Completely desaturates a color into greyscale. Same as calling desaturate(100).
-  Color get greyscale => TinyColor(this).greyscale().color;
+  Color greyscale() => TinyColor(this).greyscale().color;
 
   /// Spin the hue a given amount, from -360 to 360. Calling with 0, 360, or -360 will do nothing (since it sets the hue back to what it was before).
   Color spin([double amount = 0]) => TinyColor(this).spin(amount).color;


### PR DESCRIPTION
Since `.greyscale()` is a shorthand of another method, and it is not a property, the extension should be `.greyscale()` instead of `.greyscale`.