### PR TITLE
Upgrade to flutter 3.3.0 + lint upgrade and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Upgrade to Flutter 3.3.0
+
 ## [2.1.0] - 2022-06-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [3.0.0] - 2022-09-12
 
 - Upgrade to Flutter 3.3.0
+- Upgrade lint package to 1.1.0
 
 ## [2.1.0] - 2022-06-20
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -36,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true"
+            >
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,7 @@ class ExamplePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final TinyColor tc = TinyColor(Colors.blue);
+    final TinyColor tc = TinyColor.fromColor(Colors.blue);
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/src/conversion.dart
+++ b/lib/src/conversion.dart
@@ -1,8 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/painting.dart' show Color, HSLColor, HSVColor;
-
-import 'util.dart';
+import 'package:tinycolor2/src/util.dart';
 
 HSLColor rgbToHsl({
   required double r,

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/painting.dart';
-
-import 'tinycolor.dart';
+import 'package:tinycolor2/src/tinycolor.dart';
 
 /// Extends the Color class to allow direct TinyColor manipulation natively
 extension TinyColorExtension on Color {

--- a/lib/src/tinycolor.dart
+++ b/lib/src/tinycolor.dart
@@ -2,8 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/painting.dart' show Color, HSLColor, HSVColor;
 import 'package:pigment/pigment.dart';
-
-import 'util.dart';
+import 'package:tinycolor2/src/util.dart';
 
 class TinyColor {
   final Color originalColor;

--- a/lib/src/tinycolor.dart
+++ b/lib/src/tinycolor.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 import 'package:flutter/painting.dart' show Color, HSLColor, HSVColor;
 import 'package:pigment/pigment.dart';
 
-import 'conversion.dart';
 import 'util.dart';
 
 class TinyColor {

--- a/lib/tinycolor2.dart
+++ b/lib/tinycolor2.dart
@@ -1,6 +1,6 @@
 library tinycolor2;
 
-export 'src/extensions.dart';
 export 'src/conversion.dart';
+export 'src/extensions.dart';
 export 'src/tinycolor.dart';
 export 'src/util.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  lint: ^1.5.3
   pigment: ^1.0.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  lint: ^1.10.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: tinycolor2
 description: Flutter Color manipulation and conversion, ported from JS tinycolor2
-version: 2.1.0
+version: 3.0.0
 homepage: https://github.com/TinyCommunity/tinycolor2
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.12.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.0
 homepage: https://github.com/TinyCommunity/tinycolor2
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=1.12.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/test/tinycolor_test.dart
+++ b/test/tinycolor_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/painting.dart' show Color, HSLColor, HSVColor;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tinycolor2/tinycolor2.dart';
 
@@ -425,7 +424,7 @@ void main() {
         "==",
         () {
           expect(
-            color!,
+            color,
             TinyColor.fromColor(const Color(0xFFFFFFFF)),
           );
         },


### PR DESCRIPTION
also moved lint dependency to `dev_dependencies`, as I couldn't find any reason why it was listed under normal dependencies