### PR TITLE
Remove <4.0.0 constraints on flutter in pubspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [3.0.1] - 2022-09-15
+## [3.0.1] - 2022-09-19
 
 ### Fixed
 - Correct pubspec Flutter + Dart SDK versions at [PR #64](https://github.com/TinyCommunity/tinycolor2/pull/64)
+- Remove upper bound in pubspec Flutter + Dart SDK versions at [PR #65](https://github.com/TinyCommunity/tinycolor2/pull/65)
 
 ## [3.0.0] - 2022-09-12
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/TinyCommunity/tinycolor2
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
I will delete release 3.0.1 from releases and create it again with this PR merged